### PR TITLE
Build directly from upstream source at a known revision

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@
 name: semgrep
 
 # Version
-version: '1.0'
+version: 1.32.0
 
 # Base snap
 base: core22
@@ -13,23 +13,11 @@ grade: stable
 # Minimal access level, with permissions provided by the interfaces above
 confinement: strict
 
-# Build and run architectures
-# 
-# Despite the Python package can be installed on arm64, it will not run due to
-# reasons detailed in issue #2252 from GitHub. Based on a recent comment
-# (https://github.com/returntocorp/semgrep/issues/2252#issuecomment-1626290561)
-# from Tom Petr, a Semgrep contributor, Python wheels for arm64 will be
-# available soon.
-architectures:
-  - build-on: amd64
-
-# A Python part for "proxying" the wheel from PyPi
 parts:
   semgrep:
     plugin: python
-    source: .
-    python-packages:
-      - semgrep
+    source: https://github.com/returntocorp/semgrep.git
+    source-tag: v$SNAPCRAFT_PROJECT_VERSION
 
 # Apps, aka entry points in the snap
 # 
@@ -43,7 +31,7 @@ parts:
 #                    .dev/docs/faq/#what-network-requests-are-made
 apps:
   semgrep:
-    command: bin/python3 -m semgrep
+    command: bin/semgrep
     plugs:
       - home
       - desktop


### PR DESCRIPTION
This ensures the code contained within the semgrep snap is a known, specific version of the upstream repo. This should also allow the snap to support architectures other than amd64.

In the future, when upstream releases a new version, you can simply change the `version` field in the snapcraft.yaml and trigger a rebuild of the snap to publish this new version as the snap.