### PR TITLE
Add a github action to run a snap build for CI purposes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+name: build-snap
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: snapcore/action-build@v1


### PR DESCRIPTION
This should help ensure the snap build is always working.