### PR TITLE
Version from pip package & CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,67 @@
-name: build-snap
+name: Snap
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+
     steps:
-    - uses: actions/checkout@v3
-    - uses: snapcore/action-build@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build snap
+        id: build-snap
+        uses: snapcore/action-build@v1
+
+      - name: Upload snap
+        uses: actions/upload-artifact@v3
+        with:
+          name: snap
+          path: ${{ steps.build-snap.outputs.snap }}
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: snap
+          path: .
+
+      - name: Install snap
+        run: |
+          sudo snap install --dangerous ${{needs.build.outputs.snap-file}}
+
+      - name: Run snap
+        run: |
+          semgrep --version
+
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: snap
+        path: .
+
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      if: env.SNAPCRAFT_STORE_CREDENTIALS
+      with:
+        snap: ${{needs.build.outputs.snap-file}}
+        release: candidate

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,8 +1,8 @@
 # Identifier
 name: semgrep
 
-# Version of the snap, synced with the one of Semgrep
-version: '1.56.0'
+# Version of the snap retrieved from the pip package
+adopt-info: semgrep
 
 # Base snap
 base: core22
@@ -25,9 +25,13 @@ parts:
     source: .
     python-packages:
       - semgrep
+    override-build: |
+      craftctl default
+      version="$(python3 -m pip show semgrep | sed -n 's|^Version: ||p')"
+      craftctl set version="$version"
 
 # Apps, aka entry points in the snap
-# 
+#
 # The following plugs are used:
 # 1. Home directory access
 # 2. Network access: Semgrep communicated with its Registry to fetch rules. In
@@ -48,7 +52,7 @@ title: Semgrep
 # Sentence summarising the snap
 summary: Static code scanning
 
-# Detailed 
+# Detailed
 description: |
   Semgrep is a fast, open-source, static analysis engine for finding bugs,
   detecting vulnerabilities in third-party dependencies, and enforcing code


### PR DESCRIPTION
Set the snap version from the pip package and add a snap CI workflow.

To automatically publish the snap to the store you will need to set up the credential in `SNAPCRAFT_STORE_CREDENTIALS`, see the [action doc](https://github.com/snapcore/action-publish).